### PR TITLE
use Amazon Linux 2023 to get Ruby 3.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM amazonlinux:latest
+FROM amazonlinux:2023
 
 # Set ruby version to install
 ARG RUBY_VERSION=3.2.1
@@ -6,31 +6,19 @@ ARG RUBY_VERSION=3.2.1
 # Define custom function directory
 ARG FUNCTION_DIR="/function"
 
-# Install dependencies
-RUN yum install -y git gcc make readline-devel openssl-devel tar libyaml-devel rubygems ruby-devel
-
-# Install rbenv
-RUN git clone https://github.com/rbenv/rbenv.git ~/.rbenv
-RUN echo 'export PATH="$HOME/.rbenv/bin:$PATH"' >> ~/.bashrc
-RUN echo 'eval "$(rbenv init -)"' >> ~/.bashrc
-
-# Install ruby-build system-widely
-RUN git clone https://github.com/rbenv/ruby-build.git /tmp/ruby-build
-RUN cd /tmp/ruby-build && ./install.sh
-RUN source ~/.bashrc && rbenv install --list && rbenv install ${RUBY_VERSION} && rbenv global ${RUBY_VERSION} && \
- gem install bundler && \ 
-# Install the Runtime Interface Client 
- gem install aws_lambda_ric
-
-# Give execution permission to on root folder where gems are installed
-RUN chmod 777 /root 
+# Install ruby, bundler and the Runtime Interface Client
+RUN dnf install -y ruby \
+  && dnf clean all \
+  && gem update --system \
+  && gem install bundler \
+  && gem install aws_lambda_ric
 
 # Set working directory
 WORKDIR ${FUNCTION_DIR}
 
 # Copy Gemfile and Gemfile.lock
 COPY Gemfile Gemfile.lock ${FUNCTION_DIR}/
-RUN source ~/.bashrc && bundle config set --local deployment 'true' && bundle install
+RUN bundle config set --local deployment 'true' && bundle install
 
 # Copy layer codes
 ADD lib ${FUNCTION_DIR}/lib
@@ -39,6 +27,6 @@ ADD lib ${FUNCTION_DIR}/lib
 COPY hello_world/app.rb ${FUNCTION_DIR}/
 
 # Call lambda runtime
-ENTRYPOINT ["/root/.rbenv/shims/aws_lambda_ric"]
+ENTRYPOINT ["/usr/local/bin/aws_lambda_ric"]
 
 #CMD ["app.lambda_handler"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,5 @@
 FROM amazonlinux:2023
 
-# Set ruby version to install
-ARG RUBY_VERSION=3.2.1
-
 # Define custom function directory
 ARG FUNCTION_DIR="/function"
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,6 @@ I have created this simple HelloWorld serverless application using Ruby 3.2.1 to
 * `hello_word:` folder where the lambda code is implemented
 
 ## Dependencies
-* rbenv
 * aws_lambda_ric
 * httparty
 * dotenv


### PR DESCRIPTION
This was released on March 8th, 2023. See https://docs.aws.amazon.com/linux/al2023/ug/what-is-amazon-linux.html

DNF is a package manager the succeeds yum. You can just install it and skip the rbenv stuff.

<img width="712" alt="AmazonLinux2023_addedPkg_Ruby3 2" src="https://user-images.githubusercontent.com/5635/227734273-d067750a-c6f4-4486-99e7-117567d2568a.png">

See also: https://docs.aws.amazon.com/linux/al2023/release-notes/version-compare.html

I found the ruby gem run location only by spinning up a running container and installing the libraries as they are in the Dockerfile. The [AWS Lambda Runtime Interface Client gem](https://github.com/aws/aws-lambda-ruby-runtime-interface-client) did install, although their README states:

> The Ruby Runtime Interface Client package currently supports Ruby versions: 
> 2.5.x up to and including 2.7.x

